### PR TITLE
Fix the preview paths in the CI script

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Collect pdf previews for upload
       run: |
         mkdir -p previews/${{env.BUILD_DIR}}
-        cp src/handling_units_dimensions.tex previews/${{env.BUILD_DIR}}/
+        cp src/handling_units_dimensions.pdf previews/${{env.BUILD_DIR}}/
         test -f src/main.pdf && cp src/main.pdf previews/${{env.BUILD_DIR}}/paper-diffmain.pdf || true
 
     - name: Upload paper preview
@@ -109,7 +109,7 @@ jobs:
         issue-number: ${{github.event.number}}
         body: |
           Preview this branch rendered at <${{env.REPO_URL}}/blob/previews/${{env.BUILD_DIR}}/handling_units_dimensions.pdf>
-          Preview the latexdiff rendered at <${{env.REPO_URL}}/blob/previews/${{env.BUILD_DIR}}/paper-diffmaster.pdf>
+          Preview the latexdiff rendered at <${{env.REPO_URL}}/blob/previews/${{env.BUILD_DIR}}/paper-diffmain.pdf>
           <details>
           <summary>Click to view TexCount output</summary>
           ```


### PR DESCRIPTION
This should fix all the 404 errors when clicking the links to the previews